### PR TITLE
(179839148) Add 'latest' tags to support ECR lifecycle

### DIFF
--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -112,10 +112,30 @@ jobs:
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG--web
         if [ -f $DOCKER_ASSETS_PATH/Dockerfile.${ECR_REPOSITORY}.dj ];
         then
+          HAS_DJ=true
           echo pushing dj
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG--dj
         else
           echo not pushing dj
+        fi
+
+        echo Pushing 'latest' tags
+        BRANCH=${GITHUB_REF#refs/heads/}
+        if [[ "$BRANCH" =~ ^(production|staging|sandbox)$ ]]; then
+          LATEST_TAG="latest-$BRANCH--"
+          LATEST_BASE="$ECR_REGISTRY/$ECR_REPOSITORY:${LATEST_TAG}--base"
+          LATEST_WEB="$ECR_REGISTRY/$ECR_REPOSITORY:${LATEST_TAG}--web"
+
+          docker tag ${ECR_REPOSITORY}:latest--base $LATEST_BASE
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG--web $LATEST_WEB
+          docker push $LATEST_BASE
+          docker push $LATEST_WEB
+
+          if [ "$HAS_DJ" = "true" ]; then
+            LATEST_DJ="$ECR_REGISTRY/$ECR_REPOSITORY:${LATEST_TAG}--dj"
+            docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG--dj $LATEST_DJ
+            docker push $LATEST_DJ
+          fi
         fi
 
         echo $IMAGE_TAG--base > image-tag.txt

--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -121,8 +121,8 @@ jobs:
 
         echo Pushing 'latest' tags
         BRANCH=${GITHUB_REF#refs/heads/}
-        if [[ "$BRANCH" =~ ^(production|staging|sandbox)$ ]]; then
-          LATEST_TAG="latest-$BRANCH--"
+        if [[ "$BRANCH" =~ ^(production|staging|sandbox|demo|main)$ ]]; then
+          LATEST_TAG="latest-$BRANCH"
           LATEST_BASE="$ECR_REGISTRY/$ECR_REPOSITORY:${LATEST_TAG}--base"
           LATEST_WEB="$ECR_REGISTRY/$ECR_REPOSITORY:${LATEST_TAG}--web"
 

--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -121,7 +121,6 @@ jobs:
 
         echo Pushing 'latest' tags
         BRANCH=${GITHUB_REF#refs/heads/}
-        if [[ "$BRANCH" =~ ^(deploy-)$]]
         if [[ "$BRANCH" =~ ^(production|staging|sandbox|demo|main|deploy-.*)$ ]]; then
           IDENTIFIER=${BRANCH#deploy-} # Strip deploy prefix if present
           LATEST_TAG="latest-$IDENTIFIER"

--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -121,8 +121,10 @@ jobs:
 
         echo Pushing 'latest' tags
         BRANCH=${GITHUB_REF#refs/heads/}
-        if [[ "$BRANCH" =~ ^(production|staging|sandbox|demo|main|deploy|deploy-.*)$ ]]; then
-          LATEST_TAG="latest-$BRANCH"
+        if [[ "$BRANCH" =~ ^(deploy-)$]]
+        if [[ "$BRANCH" =~ ^(production|staging|sandbox|demo|main|deploy-.*)$ ]]; then
+          IDENTIFIER=${BRANCH#deploy-} # Strip deploy prefix if present
+          LATEST_TAG="latest-$IDENTIFIER"
           LATEST_BASE="$ECR_REGISTRY/$ECR_REPOSITORY:${LATEST_TAG}--base"
           LATEST_WEB="$ECR_REGISTRY/$ECR_REPOSITORY:${LATEST_TAG}--web"
 

--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -121,7 +121,7 @@ jobs:
 
         echo Pushing 'latest' tags
         BRANCH=${GITHUB_REF#refs/heads/}
-        if [[ "$BRANCH" =~ ^(production|staging|sandbox|demo|main)$ ]]; then
+        if [[ "$BRANCH" =~ ^(production|staging|sandbox|demo|main|deploy|deploy-.*)$ ]]; then
           LATEST_TAG="latest-$BRANCH"
           LATEST_BASE="$ECR_REGISTRY/$ECR_REPOSITORY:${LATEST_TAG}--base"
           LATEST_WEB="$ECR_REGISTRY/$ECR_REPOSITORY:${LATEST_TAG}--web"


### PR DESCRIPTION
This adds tags for the web, base, and dj images: `latest-{env:production|staging|sandbox}--{variant:web|base|dj}`. The `env` is based on branch name, meaning that this won't apply `latest-` tags to images on branches other than prod/staging/sandbox.

This is tested and implemented in HNMI: https://github.com/greenriver/hnmi/pull/1128